### PR TITLE
Keep current focus when post window opens

### DIFF
--- a/lib/controller.coffee
+++ b/lib/controller.coffee
@@ -117,12 +117,15 @@ class Controller
               'line',
               'line-highlight')
 
+      currentView = atom.views.getView atom.workspace.getActiveTextEditor()
+
       options =
         split: 'right'
         searchAllPanes: true
       atom.workspace.open(uri, options)
         .then () =>
           @activateRepl @repls[uri]
+          currentView.focus()
           $('.post-window').on 'click', fileOpener
 
   clearPostWindow: ->


### PR DESCRIPTION
When evaluating code auto-opens the post window, this prevents current item focus to be lost.