### PR TITLE
[WIP] autocomplete-plus support

### DIFF
--- a/lib/autocomplete.coffee
+++ b/lib/autocomplete.coffee
@@ -1,19 +1,93 @@
+fuzz = require('fuzzaldrin-plus')
+
 module.exports =
 class AutoCompleter
   constructor: (repl) ->
     @repl = repl
     @classes = null
     @docs = null
+    # pre-allocate so it only gets compiled once
+    # look for some set of period-separated identifiers before the cursor
+    @prefixRegex = /([A-Za-z0-9_.]*)$/
+
+  handleNakedPrefix: (prefix) ->
+    # currently we onyly have classes in our naked database. If we
+    # add global variables we'll need to tweak this
+    names = fuzz.filter(@classes, prefix, {maxResults: 20})
+    return ({
+      text: name,
+      description: @docs["Classes/#{name}"],
+      type: "class"} for name in names)
+
+  handleClassMemberPrefix: (className, prefix) ->
+    candidates = []
+    return @getClassMethods(className)
+      .then (methods) =>
+        for m in methods
+          candidates.push({
+            text: m.name,
+            description: @makeMethodString(m),
+            type: "method"
+          })
+        return candidates
+
+  makeMethodString: (method) ->
+    argStrings = []
+    sep = ", "
+    N = method.args.length
+    if N == 0
+      # no arguments, show without parens
+      return method.name
+    for i in [0..(N-1)]
+      if method.argDefaults[i] == null
+        argStrings.push(method.args[i])
+      else
+        argStrings.push("#{method.args[i]}=#{method.argDefaults[i]}")
+    return "#{method.name}(#{argStrings.join(sep)})"
+
+  # these introspection commands return nil instead of an empty list
+  # if there aren't any methods/vars. bummer.
+  getClassMethods: (className) ->
+    code = """
+    if(#{className}.class.methods.isNil, {[]}, {
+      #{className}.class.methods.collect {
+      	arg m;
+      	(
+      		\\name: m.name,
+      		\\args: if(m.argNames.isNil, {[]}, {m.argNames[1..]}),
+      		\\argDefaults: if(m.prototypeFrame.isNil, {[]}, {m.prototypeFrame[1..]})
+      	)
+      }
+    })
+    """
+    return @repl.eval(code, true, null, false, false)
+
+  getClassVars: (className) ->
+    code = """
+    if(#{className}.classVarNames.isNil, {[]}, {
+      #{className}.classVarNames
+    })
+    """
+    return @repl.eval(code, true, null, false, false)
 
   updateClassList: () ->
-    @repl.eval('Class.allClasses', false, null, false)
+    @repl.eval('Class.allClasses', true, null, false, false)
       .then (result) =>
         @classes = result
-    @repl.eval('SCDoc.documents', false, null, false)
+    @repl.eval('SCDoc.documents.collect {arg doc; doc.summary}',
+               true, null, false, false)
       .then (result) =>
-        console.log("got results")
         @docs = result
 
-
-  getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix, activatedManually}) =>
-    return ({text: cls, type: 'class'} for cls in @classes)
+  getSuggestions: ({editor, bufferPosition}) =>
+     # Get the text for the line up to the triggered buffer position
+    line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+    # this regex matches empty, so we should always get something
+    prefix = line.match(@prefixRegex)[0]
+    objs = prefix.split('.');
+    if objs.length == 1
+      return @handleNakedPrefix(objs[0])
+    else if objs.length == 2 && objs[0] in @classes
+      return @handleClassMemberPrefix(objs[0], objs[1])
+    else
+      return []

--- a/lib/autocomplete.coffee
+++ b/lib/autocomplete.coffee
@@ -1,0 +1,19 @@
+module.exports =
+class AutoCompleter
+  constructor: (repl) ->
+    @repl = repl
+    @classes = null
+    @docs = null
+
+  updateClassList: () ->
+    @repl.eval('Class.allClasses', false, null, false)
+      .then (result) =>
+        @classes = result
+    @repl.eval('SCDoc.documents', false, null, false)
+      .then (result) =>
+        console.log("got results")
+        @docs = result
+
+
+  getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix, activatedManually}) =>
+    return ({text: cls, type: 'class'} for cls in @classes)

--- a/lib/controller.coffee
+++ b/lib/controller.coffee
@@ -19,8 +19,8 @@ class Controller
     @scScope = 'source.supercollider'
     @provider =
       selector: '.source.supercollider'
-      inclusionPriority: 1
-      # excludeLowerPriority: true
+      inclusionPriority: 10
+      excludeLowerPriority: true
       filterSuggestions: true
       getSuggestions: (options) =>
         @activeRepl.getSuggestions(options)

--- a/lib/controller.coffee
+++ b/lib/controller.coffee
@@ -17,6 +17,14 @@ class Controller
     @activeRepl = null
     @markers = []
     @scScope = 'source.supercollider'
+    @provider =
+      selector: '.source.supercollider'
+      inclusionPriority: 1
+      # excludeLowerPriority: true
+      filterSuggestions: true
+      getSuggestions: (options) =>
+        @activeRepl.getSuggestions(options)
+
 
   start: ->
     atom.commands.add 'atom-workspace',

--- a/lib/repl.coffee
+++ b/lib/repl.coffee
@@ -24,7 +24,7 @@ class Repl
     @makeBus()
     @state = null
     @debug = atom.config.get 'supercollider.debug'
-    @autocompleter = new AutoCompleter()
+    @autocompleter = new AutoCompleter(@)
     if @debug
       console.log 'Supercollider REPL [DEBUG=true]'
 
@@ -39,11 +39,6 @@ class Repl
       @onClose()
 
     @postWindow = new PostWindow(@uri, @postBus, onClose)
-
-  updateClassList: () ->
-    @eval('Class.allClasses', false, null, false)
-      .then (result) =>
-        @autocompleter.setClasses(result)
 
   getSuggestions: (options) ->
     @autocompleter.getSuggestions(options)
@@ -90,7 +85,7 @@ class Repl
       if @debug
         console.log 'booted'
       @ready.resolve()
-      @updateClassList()
+      @autocompleter.updateClassList()
 
     fail = (error) =>
       # dirs

--- a/lib/repl.coffee
+++ b/lib/repl.coffee
@@ -204,14 +204,16 @@ class Repl
 
     return opts
 
-  eval: (expression, noecho=false, nowExecutingPath=null, returnString=true) ->
+  eval: (expression, noecho=false, nowExecutingPath=null,
+         returnString=true, printResult=true) ->
 
     deferred = Q.defer()
 
     ok = (result) =>
-      # we need to convert to string for printing if our output is a JSON object
-      printable = if returnString then result else JSON.stringify(result)
-      @postBus.push "<div class='pre out'>#{printable}</div>"
+      if printResult
+        # we need to convert to string for printing if our output is a JSON object
+        printable = if returnString then result else JSON.stringify(result)
+        @postBus.push "<div class='pre out'>#{printable}</div>"
       deferred.resolve(result)
 
     err = (error) =>

--- a/lib/supercollider.coffee
+++ b/lib/supercollider.coffee
@@ -38,3 +38,6 @@ module.exports =
 
   serialize: ->
     {}
+
+  provide: () ->
+    @controller.provider

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "atom-space-pen-views": "^2.2.0",
     "baconjs": "^0.7.89",
     "escape-html": "~1.0.3",
+    "fuzzaldrin-plus": "^0.5.0",
     "growl": "^1.9.2",
     "jquery": "^2",
     "moment": "^2.17.1",

--- a/package.json
+++ b/package.json
@@ -31,5 +31,12 @@
       "supercollider:cmd-period",
       "supercollider:manage-quarks"
     ]
+  },
+  "providedServices": {
+    "autocomplete.provider": {
+      "versions": {
+        "2.0.0": "provide"
+      }
+    }
   }
 }


### PR DESCRIPTION
This is a first cut at autocomplete support. It assumes you're using
supercolliderjs with my recent socket PR.

Here it pulls the list of class names and documentation summaries right after
booting the server, and queries for class methods on-the-fly.

I agree with your comment elsewhere that loading the class info from a file
would be nice so we can still auto-complete if SCLang is crashing or otherwise
unavailable. The balance is basically making sure that the autocompletion is
up-to-date whenever possible, so if the user adds a Quark or custom class it
should show up after their next reboot. In general a reasonable fallback plan
seems like:

1. Use fresh data (from the last SCLang boot) whenever possible
2. If SCLang didn't boot successfully, use a cached copy from the last boot
3. If there are no cached copies, load from a default file that ships with the
   package with all the classes that ship with SC.

I'll test out whether getting all the class methods is fast enough to do it
up-front rather then at autocomplete-time.

Still more to do (this is somewhat aspirational, we'll see how far I get):

* [ ] handle inherited methods
* [ ] merge Class.prop and Class.prop_ methods with some
      readable/writable indication
* [ ] figure out cacheing for when SCLang is unavailable
* [ ] better feedback when you're in the middle of an argument list
      (maybe snippet support?)
* [ ] add variable support - if we can statically figure out the class of a
      variable it would be great to be able to autocomplete instance
      members/methods
* [ ] incorporate the regular text-based autocomplete so we also complete
      identifiers in the file.

I'll add a demo gif shortly. :)