### PR TITLE
Added keywords, regex for functional notation highlighting, quit lang shortcut, updated README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 node_modules
 tags
 doing
+.npmignore

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.DS_Store
-npm-debug.log
-node_modules
-tags
-doing

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.DS_Store
+npm-debug.log
+node_modules
+tags
+doing

--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ See the [supercollider.js configuration documentation](http://supercolliderjs.re
 
 `"C:\Program Files\SuperCollider\sclang.exe"`
 
+## Themes
+
+A couple SuperCollider-specific themes have been created to add symbol colorization, argument tags, argument parameters in pipes, and function names when using functional notation: [Woolgathering Light Syntax](https://atom.io/themes/woolgathering-light-syntax) and [Woolgathering Dark Syntax](https://atom.io/themes/woolgathering-dark-syntax).
 
 ## Missing Features
 

--- a/grammars/supercollider.cson
+++ b/grammars/supercollider.cson
@@ -59,6 +59,11 @@
         'name': 'entity.name.class.supercollider'
     'match': '[^a-zA-Z0-9\\\\]([A-Z_]{1}[a-zA-Z0-9_]*)[^a-zA-Z0-9_]'
   }
+    # attempting to get arguments in the form *: to highlight...
+  {
+    'match': '([a-zA-Z\d])+:'
+    'name': 'entity.name.argument.supercollider'
+  }
   {
     'match': '\\\\[a-zA-Z0-9\\_]+'
     'name': 'entity.name.symbol.supercollider'

--- a/grammars/supercollider.cson
+++ b/grammars/supercollider.cson
@@ -8,7 +8,7 @@
 'name': 'SuperCollider'
 'patterns': [
   {
-    'match': '\\b(arg|var|classvar|const|this|thisThread|thisMethod|thisFunction|thisProcess|true|false|inf|nil|for|forBy|if|switch|which|case|pi)\\b'
+    'match': '\\b(arg|var|classvar|const|this|thisThread|thisMethod|thisFunction|thisProcess|true|false|inf|nil|for|forBy|if|switch|which|case|pi|while)\\b'
     'name': 'keyword.control.supercollider'
   }
   {
@@ -59,11 +59,6 @@
         'name': 'entity.name.class.supercollider'
     'match': '[^a-zA-Z0-9\\\\]([A-Z_]{1}[a-zA-Z0-9_]*)[^a-zA-Z0-9_]'
   }
-    # attempting to get arguments in the form *: to highlight... (Note: hack fix in syntax files. See woolgathering-light/dark-syntax)
-  {
-    'match': '([a-zA-Z\d])+:'
-    'name': 'entity.name.argument.supercollider'
-  }
   # find *pi as keyword
   {
     'match': '([0-9\d])+pi'
@@ -91,6 +86,10 @@
     'begin': '\\/\\*'
     'end': '\\*\\/'
     'name': 'comment.multiline.supercollider'
+  }
+  {
+    'match': '(^[a-z]{1}\\w+)(?=\\()'
+    'name': 'entity.name.functional-name.supercollider'
   }
   {
     'comment': 'source: ruby bundle'

--- a/grammars/supercollider.cson
+++ b/grammars/supercollider.cson
@@ -8,7 +8,7 @@
 'name': 'SuperCollider'
 'patterns': [
   {
-    'match': '\\b(arg|var|classvar|const|this|thisThread|thisMethod|thisFunction|thisProcess|true|false|inf|nil)\\b'
+    'match': '\\b(arg|var|classvar|const|this|thisThread|thisMethod|thisFunction|thisProcess|true|false|inf|nil|for|forBy|if|switch|which|case|pi)\\b'
     'name': 'keyword.control.supercollider'
   }
   {
@@ -59,10 +59,15 @@
         'name': 'entity.name.class.supercollider'
     'match': '[^a-zA-Z0-9\\\\]([A-Z_]{1}[a-zA-Z0-9_]*)[^a-zA-Z0-9_]'
   }
-    # attempting to get arguments in the form *: to highlight...
+    # attempting to get arguments in the form *: to highlight... (Note: hack fix in syntax files. See woolgathering-light/dark-syntax)
   {
     'match': '([a-zA-Z\d])+:'
     'name': 'entity.name.argument.supercollider'
+  }
+  # find *pi as keyword
+  {
+    'match': '([0-9\d])+pi'
+    'name': 'keyword.control.supercollider'
   }
   {
     'match': '\\\\[a-zA-Z0-9\\_]+'

--- a/keymaps/supercollider.cson
+++ b/keymaps/supercollider.cson
@@ -10,15 +10,17 @@
 
 # Windows and Linux
 'atom-workspace':
-  'shift-alt-k': 'supercollider:clear-post-window'
+  'shift-alt-c': 'supercollider:clear-post-window'
 "atom-workspace atom-text-editor[data-grammar~='supercollider']":
+  'shift-alt-k': 'supercollider:recompile'
   'ctrl-alt-l': 'supercollider:open-post-window'
   'shift-enter': 'supercollider:eval'
   'alt-.': 'supercollider:cmd-period'
-  'shift-alt-k': 'supercollider:clear-post-window'
+  'shift-alt-c': 'supercollider:clear-post-window'
   'ctrl-shift-h': 'supercollider:open-help-file'
   'alt-shift-b': 'supercollider:boot-server'
   'alt-shift-q': 'supercollider:quit-server'
+  'alt-shift-q-l': 'supercollider:quit-lang'
 
 # OS X
 '.platform-darwin atom-workspace':

--- a/keymaps/supercollider.cson
+++ b/keymaps/supercollider.cson
@@ -20,7 +20,7 @@
   'ctrl-shift-h': 'supercollider:open-help-file'
   'alt-shift-b': 'supercollider:boot-server'
   'alt-shift-q': 'supercollider:quit-server'
-  'shift-alt-x': 'supercollider:quit-lang'
+  'shift-alt-ctrl-x': 'supercollider:quit-lang'
 
 # OS X
 '.platform-darwin atom-workspace':

--- a/keymaps/supercollider.cson
+++ b/keymaps/supercollider.cson
@@ -20,7 +20,7 @@
   'ctrl-shift-h': 'supercollider:open-help-file'
   'alt-shift-b': 'supercollider:boot-server'
   'alt-shift-q': 'supercollider:quit-server'
-  'alt-shift-q-l': 'supercollider:quit-lang'
+  'shift-alt-x': 'supercollider:quit-lang'
 
 # OS X
 '.platform-darwin atom-workspace':

--- a/lib/controller.coffee
+++ b/lib/controller.coffee
@@ -30,6 +30,8 @@ class Controller
     atom.commands.add 'atom-workspace',
       'supercollider:boot-server', => @bootServer()
     atom.commands.add 'atom-workspace',
+      'supercollider:quit-lang', => @quitLang()
+    atom.commands.add 'atom-workspace',
       'supercollider:quit-server', => @quitServer()
     atom.commands.add 'atom-workspace',
       'supercollider:reboot-server', => @rebootServer()
@@ -138,7 +140,7 @@ class Controller
       currentView = atom.views.getView atom.workspace.getActiveTextEditor()
 
       options =
-        split: (atom.config.get 'openPostWindowOn') || 'right'
+        split: (atom.config.get 'openPostWindowOn') || 'down'
         searchAllPanes: true
       atom.workspace.open(uri, options)
         .then () =>
@@ -165,6 +167,9 @@ class Controller
 
   quitServer: () ->
     @evalWithRepl('Server.default.quit;')
+
+  quitLang: () ->
+    @evalWithRepl('0.exit;')
 
   rebootServer: () ->
     @evalWithRepl('Server.default.reboot;')

--- a/settings/language-supercollider.cson
+++ b/settings/language-supercollider.cson
@@ -2,5 +2,5 @@
   'editor':
     'autoIndentOnPaste': true
     'softTabs': false
-    'tabLength': 4
+    'tabLength': 2
     'commentStart': '// '

--- a/styles/supercollider.less
+++ b/styles/supercollider.less
@@ -323,3 +323,8 @@ atom-text-editor.editor.is-focused.insert-mode .line.cursor-line
 span.entity.name.symbol {
   color: @syntax-color-tag;
 }
+
+// trying to get arguments in the form *: to highlight...
+span.entity.name.argument {
+  color: @syntax-color-tag;
+}

--- a/styles/supercollider.less
+++ b/styles/supercollider.less
@@ -317,14 +317,3 @@ atom-text-editor.editor.is-focused.insert-mode .line.cursor-line
 .unfolder:checked ~ label .unfold-icon {
   display: none;
 }
-// a hack for the syntax colors
-// because most syntax themes do not
-// specify a color for symbol
-span.entity.name.symbol {
-  color: @syntax-color-tag;
-}
-
-// trying to get arguments in the form *: to highlight...
-span.entity.name.argument {
-  color: @syntax-color-tag;
-}


### PR DESCRIPTION
A few random updates I use on my end that might be useful to all users. There are a few personal customizations that we'd probably not want to merge: tablength, clear post window shortcut, and post window on the bottom.

New keywords (for, forBy, if, switch, which, case, pi, while), regex to catch multiples of pi (2pi, 3pi, etc), added ability to quit the language from a keyboard shortcut.

I also updated the Woolgathering Dark/Light Syntaxes to highlight function names if one is writing using functional notation. To do this, this update is needed (lines 90-93 in grammars/supercollider.cson).