### PR TITLE
Code block compilation

### DIFF
--- a/keymaps/supercollider.cson
+++ b/keymaps/supercollider.cson
@@ -14,6 +14,7 @@
 "atom-workspace atom-text-editor[data-grammar~='supercollider']":
   'ctrl-alt-l': 'supercollider:open-post-window'
   'shift-enter': 'supercollider:eval'
+  'alt-enter': 'supercollider:evalBlock'
   'alt-.': 'supercollider:cmd-period'
   'shift-alt-k': 'supercollider:clear-post-window'
   'ctrl-shift-h': 'supercollider:open-help-file'
@@ -26,6 +27,7 @@
 ".platform-darwin atom-workspace atom-text-editor[data-grammar~='supercollider']":
   'cmd-\\': 'supercollider:open-post-window'
   'shift-enter': 'supercollider:eval'
+  'cmd-enter': 'supercollider:evalBlock'
   'shift-cmd-k': 'supercollider:recompile'
   'cmd-.': 'supercollider:cmd-period'
   'shift-cmd-c': 'supercollider:clear-post-window'

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "activationCommands": {
     "atom-workspace": [
       "supercollider:eval",
+      "supercollider:evalBlock",
       "supercollider:open-post-window",
       "supercollider:clear-post-window",
       "supercollider:open-help-file",


### PR DESCRIPTION
This allows for `cmd-enter` compilation of a code block surrounded at the top level by `()` or `{}` pairs.

All code is taken from https://github.com/jasongilman/proto-repl and adapted to the scenario.

If no top level code block is found it defaults to the `@eval` method.