### PR TITLE
Updated keywords and syntax, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ See the [supercollider.js configuration documentation](http://supercolliderjs.re
 
 `"C:\Program Files\SuperCollider\sclang.exe"`
 
+## Themes
+
+A couple SuperCollider-specific themes have been created to add symbol colorization, argument tags, argument parameters in pipes, and function names when using functional notation: [Woolgathering Light Syntax](https://atom.io/themes/woolgathering-light-syntax) and [Woolgathering Dark Syntax](https://atom.io/themes/woolgathering-dark-syntax).
 
 ## Missing Features
 

--- a/grammars/supercollider.cson
+++ b/grammars/supercollider.cson
@@ -8,7 +8,7 @@
 'name': 'SuperCollider'
 'patterns': [
   {
-    'match': '\\b(arg|var|classvar|const|this|thisThread|thisMethod|thisFunction|thisProcess|true|false|inf|nil|for|forBy|if|switch|which|case|pi|while)\\b'
+    'match': '\\b(arg|var|classvar|const|this|thisThread|thisMethod|thisFunction|thisProcess|true|false|inf|nil|for|forBy|if|switch|which|case|pi|super|const)\\b'
     'name': 'keyword.control.supercollider'
   }
   {
@@ -59,10 +59,18 @@
         'name': 'entity.name.class.supercollider'
     'match': '[^a-zA-Z0-9\\\\]([A-Z_]{1}[a-zA-Z0-9_]*)[^a-zA-Z0-9_]'
   }
+  {
+    'match': '([a-zA-Z\d])+:'
+    'name': 'entity.name.argument.supercollider'
+  }
   # find *pi as keyword
   {
     'match': '([0-9\d])+pi'
     'name': 'keyword.control.supercollider'
+  }
+  {
+    'match': '^(?<=\s)([a-zA-Z\d])+(?=\(.\))'
+    'name': 'entity.name.functionname.supercollider'
   }
   {
     'match': '\\\\[a-zA-Z0-9\\_]+'

--- a/grammars/supercollider.cson
+++ b/grammars/supercollider.cson
@@ -8,7 +8,7 @@
 'name': 'SuperCollider'
 'patterns': [
   {
-    'match': '\\b(arg|var|classvar|const|this|thisThread|thisMethod|thisFunction|thisProcess|true|false|inf|nil|for|forBy|if|switch|which|case|pi)\\b'
+    'match': '\\b(arg|var|classvar|const|this|thisThread|thisMethod|thisFunction|thisProcess|true|false|inf|nil|for|forBy|if|switch|which|case|pi|while)\\b'
     'name': 'keyword.control.supercollider'
   }
   {
@@ -59,11 +59,6 @@
         'name': 'entity.name.class.supercollider'
     'match': '[^a-zA-Z0-9\\\\]([A-Z_]{1}[a-zA-Z0-9_]*)[^a-zA-Z0-9_]'
   }
-    # attempting to get arguments in the form *: to highlight... (Note: hack fix in syntax files. See woolgathering-light/dark-syntax)
-  {
-    'match': '([a-zA-Z\d])+:'
-    'name': 'entity.name.argument.supercollider'
-  }
   # find *pi as keyword
   {
     'match': '([0-9\d])+pi'
@@ -91,6 +86,10 @@
     'begin': '\\/\\*'
     'end': '\\*\\/'
     'name': 'comment.multiline.supercollider'
+  }
+  {
+    'match': '(^[a-z]{1}\\w+)(?=\\()'
+    'name': 'entity.name.functional-name.supercollider'
   }
   {
     'comment': 'source: ruby bundle'

--- a/grammars/supercollider.cson
+++ b/grammars/supercollider.cson
@@ -8,7 +8,7 @@
 'name': 'SuperCollider'
 'patterns': [
   {
-    'match': '\\b(arg|var|classvar|const|this|thisThread|thisMethod|thisFunction|thisProcess|true|false|inf|nil)\\b'
+    'match': '\\b(arg|var|classvar|const|this|thisThread|thisMethod|thisFunction|thisProcess|true|false|inf|nil|for|forBy|if|switch|which|case|pi)\\b'
     'name': 'keyword.control.supercollider'
   }
   {
@@ -58,6 +58,16 @@
       '1':
         'name': 'entity.name.class.supercollider'
     'match': '[^a-zA-Z0-9\\\\]([A-Z_]{1}[a-zA-Z0-9_]*)[^a-zA-Z0-9_]'
+  }
+    # attempting to get arguments in the form *: to highlight... (Note: hack fix in syntax files. See woolgathering-light/dark-syntax)
+  {
+    'match': '([a-zA-Z\d])+:'
+    'name': 'entity.name.argument.supercollider'
+  }
+  # find *pi as keyword
+  {
+    'match': '([0-9\d])+pi'
+    'name': 'keyword.control.supercollider'
   }
   {
     'match': '\\\\[a-zA-Z0-9\\_]+'

--- a/keymaps/supercollider.cson
+++ b/keymaps/supercollider.cson
@@ -20,6 +20,7 @@
   'ctrl-shift-h': 'supercollider:open-help-file'
   'alt-shift-b': 'supercollider:boot-server'
   'alt-shift-q': 'supercollider:quit-server'
+  'shift-alt-ctrl-x': 'supercollider:quit-lang'
 
 # OS X
 '.platform-darwin atom-workspace':

--- a/lib/controller.coffee
+++ b/lib/controller.coffee
@@ -30,6 +30,8 @@ class Controller
     atom.commands.add 'atom-workspace',
       'supercollider:boot-server', => @bootServer()
     atom.commands.add 'atom-workspace',
+      'supercollider:quit-lang', => @quitLang()
+    atom.commands.add 'atom-workspace',
       'supercollider:quit-server', => @quitServer()
     atom.commands.add 'atom-workspace',
       'supercollider:reboot-server', => @rebootServer()
@@ -167,6 +169,9 @@ class Controller
 
   quitServer: () ->
     @evalWithRepl('Server.default.quit;')
+
+  quitLang: () ->
+    @evalWithRepl('0.exit;')
 
   rebootServer: () ->
     @evalWithRepl('Server.default.reboot;')


### PR DESCRIPTION
FINALLY got around to putting the changes to keywords and syntax in their own branch (and it only took a global catastrophe to get me to do it).

Additions:
- new keywords: _for, forBy, if, switch, which, case, pi, while_
- regex to catch multiples of pi (2pi, 3pi, etc)
- ability to quit the language from a keyboard shortcut

If you're using the Woolgathering Dark/Light Syntaxes, function name notation highlights as expected.